### PR TITLE
Reduced time precision

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,14 @@ name: Auto Merge Workflow
 
 on:
   pull_request:
+    types: [assigned, unassigned, labeled, unlabeled, opened, edited, closed, reopened, synchronize, ready_for_review, locked, unlocked, review_requested, review_request_removed]
     branches:
       - "*"
   issues:
     types:
       - labeled
+          
+
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   AUTOMERGE_BRANCHES: "master,release,develop"

--- a/action.js
+++ b/action.js
@@ -102,7 +102,7 @@ const getAutomaticPRConfig = (head, base, author, failedBranch = undefined) => {
         body = matchBody[1]
     }
     return {
-        title: `[automerge][${head} -> ${failedBranch || base}][${Math.floor(
+        title: `[automerge][${head} -> ${failedBranch ?? base}][${Math.floor(
             Date.now() / 60000
         )}]${failedBranch ? ' FAILED ' : ''} ${title}`,
         body: `Triggered by [PR ${PULL_REQUEST.number}](${PULL_REQUEST.html_url}) merge. Authored by ${author}\n\n${body}`,


### PR DESCRIPTION
To offer protection against timing attacks and [fingerprinting](https://developer.mozilla.org/en-US/docs/Glossary/Fingerprinting), the precision of Date.now() might get rounded depending on browser settings. In Firefox, the privacy.reduceTimerPrecision preference is enabled by default and defaults to 2ms. You can also enable privacy.resistFingerprinting, in which case the precision will be 100ms or the value of privacy.resistFingerprinting.reduceTimerPrecision.microseconds, whichever is larger.

JS